### PR TITLE
Feat: CircleCI CICD setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
       - run: mkdir src test
       - run: mv output/src src
       - run: mv output/test test
+      - run: ls -la src
+      - run: ls -la test
       - run: cd ./test && make all
       - persist_to_workspace:
           root: exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - checkout
       - run: cd ./src && make lib
       - run: mkdir output && mv src/libtestfunctions.a output
+      - run: mkdir output/test && mv test output/test
       - run: ls -la
       - persist_to_workspace:
           root: output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+workflows:
+  version: 2.1
+  lib-compile:
+    jobs:
+      - compile
+      - test:
+          requires: 
+            - compile
+
+jobs:
+  compile:
+    docker:
+      - image: gcc:8.2
+    steps:
+      - checkout
+      - run: 
+          name: make lib
+          command: cd ./src && make lib
+
+  test:
+    docker:
+      - image: gcc:8.2
+    steps:
+      - run:
+          name: compile tests
+          command: cd ./test && make all
+      - run:
+          name: run tests
+          command: ./test/test.exe
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
       - checkout
       - run: cd ./src && make lib
       - run: mkdir output output/src output/test
-      - run: mv src/libtestfunctions.a output/src
+      - run: mv src/*.a output/src
+      - run: mv src/*.h output/src
       - run: mv test/* output/test
-      - run: ls -la output
       - persist_to_workspace:
           root: output
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run: 
           name: make lib
-          command: cd ./src && make lib
+          command: (cd ./src && make lib)
 
   test:
     docker:
@@ -25,7 +25,7 @@ jobs:
     steps:
       - run:
           name: compile tests
-          command: cd ./test && make all
+          command: (cd ./test && make all)
       - run:
           name: run tests
           command: ./test/test.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,15 @@ jobs:
       - run:
           name: make test
           command: cd ./test && make all
+      - persist_to_workspace:
+          root: test
 
   test:
     docker:
       - image: gcc:8.2
     steps:
-      - checkout
+      - attach_workspace:
+          at: test
       - run:
           name: run tests
           command: ./test/test.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
           root: output
           paths:
             - src/*.a
+            - src/*.h
             - test/*
   
   compile_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,15 @@ jobs:
       - run: 
           name: make lib
           command: cd ./src && make lib && cd -
+      - run:
+          name: make test
+          command: cd ./test && make all & cd -
 
   test:
     docker:
       - image: gcc:8.2
     steps:
       - checkout
-      - run:
-          name: compile tests
-          command: cd ./test && make all && cd -
       - run:
           name: run tests
           command: ./test/test.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
     docker:
       - image: gcc:8.2
     steps:
+      - checkout
       - run:
           name: compile tests
           command: (cd ./test && make all)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,35 +2,49 @@ version: 2.1
 
 workflows:
   version: 2.1
-  lib-compile:
+  compile_and_test:
     jobs:
-      - compile
-      - test:
-          requires: 
-            - compile
+      - compile_lib
+      - compile_tests:
+          requires:
+            - compile_lib
+      - run_tests:
+          requires:
+            - compile_tests
 
 jobs:
-  compile:
+  compile_lib:
     docker:
       - image: gcc:8.2
     steps:
       - checkout
-      - run: 
-          name: make lib
-          command: cd ./src && make lib
-      - run:
-          name: make test
-          command: cd ./test && make all
+      - run: cd ./src && make lib
+      - run: mkdir output && mv src/libtestfunctions.a output
+      - run: ls -la
       - persist_to_workspace:
-          root: test
-
-  test:
+          root: output
+          paths:
+            - "*.a"
+  
+  compile_tests:
     docker:
       - image: gcc:8.2
     steps:
       - attach_workspace:
-          at: test
-      - run:
-          name: run tests
-          command: ./test/test.exe
+          at: output
+      - run: ls -la
+      - run: mv output/* src
+      - run: cd ./test && make all
+      - persist_to_workspace:
+          root: exe
+          paths:
+            - "*.exe"
+
+  run_tests:
+    docker:
+      - image: gcc:8.2
+    steps:
+      - attach_workspace:
+          at: exe
+      - run: exe/test.exe
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run: 
           name: make lib
-          command: (cd ./src && make lib)
+          command: cd ./src && make lib && cd -
 
   test:
     docker:
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - run:
           name: compile tests
-          command: (cd ./test && make all)
+          command: cd ./test && make all && cd -
       - run:
           name: run tests
           command: ./test/test.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,7 @@ jobs:
       - image: gcc:8.2
     steps:
       - attach_workspace:
-          at: output
-      - run: mkdir src test
-      - run: mv output/src src/*
-      - run: mv output/test test/*
+          at: .
       - run: ls -la src
       - run: ls -la test
       - run: cd ./test && make all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run: ls -la test
       - run: cd ./test && make all
       - persist_to_workspace:
-          root: exe
+          root: test
           paths:
             - "*.exe"
 
@@ -49,6 +49,6 @@ jobs:
       - image: gcc:8.2
     steps:
       - attach_workspace:
-          at: exe
-      - run: exe/test.exe
+          at: .
+      - run: ./test.exe
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,10 @@ jobs:
       - checkout
       - run: 
           name: make lib
-          command: cd ./src && make lib && cd -
+          command: cd ./src && make lib
       - run:
           name: make test
-          command: cd ./test && make all & cd -
+          command: cd ./test && make all
 
   test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,14 +19,15 @@ jobs:
     steps:
       - checkout
       - run: cd ./src && make lib
-      - run: mkdir output/src output/test
+      - run: mkdir output output/src output/test
       - run: mv src/libtestfunctions.a output/src
       - run: mv test output/test
       - run: ls -la output
       - persist_to_workspace:
           root: output
           paths:
-            - "*.a"
+            - src/*.a
+            - test/*
   
   compile_tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,10 @@ jobs:
     steps:
       - checkout
       - run: cd ./src && make lib
-      - run: mkdir output && mv src/libtestfunctions.a output
-      - run: mkdir output/test && mv test output/test
-      - run: ls -la
+      - run: mkdir output/src output/test
+      - run: mv src/libtestfunctions.a output/src
+      - run: mv test output/test
+      - run: ls -la output
       - persist_to_workspace:
           root: output
           paths:
@@ -33,8 +34,9 @@ jobs:
     steps:
       - attach_workspace:
           at: output
-      - run: ls -la
-      - run: mv output/* src
+      - run: mkdir src test
+      - run: mv output/src src
+      - run: mv output/test test
       - run: cd ./test && make all
       - persist_to_workspace:
           root: exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run: cd ./src && make lib
       - run: mkdir output output/src output/test
       - run: mv src/libtestfunctions.a output/src
-      - run: mv test output/test
+      - run: mv test/* output/test
       - run: ls -la output
       - persist_to_workspace:
           root: output
@@ -36,8 +36,8 @@ jobs:
       - attach_workspace:
           at: output
       - run: mkdir src test
-      - run: mv output/src src
-      - run: mv output/test test
+      - run: mv output/src src/*
+      - run: mv output/test test/*
       - run: ls -la src
       - run: ls -la test
       - run: cd ./test && make all

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,4 +7,4 @@ DEPS = $(TEST:.c=.d)
 -include ${DEPS}
 
 all: ${OBJS}
-	${CC} ${CFLAGS} -o test.exe ${OBJS} ../src/libtestfunctions.a
+	${CC} ${CFLAGS} -o test.exe ${OBJS} ./src/libtestfunctions.a

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,4 +7,4 @@ DEPS = $(TEST:.c=.d)
 -include ${DEPS}
 
 all: ${OBJS}
-	${CC} ${CFLAGS} -o test.exe ${OBJS} ./src/libtestfunctions.a
+	${CC} ${CFLAGS} -o test.exe ${OBJS} ../src/libtestfunctions.a


### PR DESCRIPTION
### Features

- Configuring CircleCI for CICD

### Notes

CircleCI is currently used for compiling the library, test suite, & running tests.